### PR TITLE
Added support for Sodaq Mbili and EnviroDIY Mayfly

### DIFF
--- a/EnableInterrupt.h
+++ b/EnableInterrupt.h
@@ -1038,12 +1038,9 @@ void enableInterrupt(uint8_t interruptDesignator, interruptFunctionType userFunc
 /*{{{*/
 #if defined ARDUINO_328
   if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 2 && arduinoPin != 3) ) {
-#elif defined ARDUINO_AVR_ENVIRODIY_MAYFLY || defined ARDUINO_AVR_SODAQ_MBILI
-  if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 10 && arduinoPin != 2 &&
-                                                      arduinoPin != 3) ) {
 #elif defined MIGHTY1284
-  if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 2 && arduinoPin != 10 &&
-                                                      arduinoPin != 11) ) {
+  if ( (interruptDesignator & PINCHANGEINTERRUPT) ||
+     (arduinoPin != ARDUINO_PIN_B2 && arduinoPin != ARDUINO_PIN_D2 && arduinoPin != ARDUINO_PIN_D3) ) {
 #elif defined ARDUINO_LEONARDO
   if ( (arduinoPin > 3) && (arduinoPin != 7) ) {
 #elif defined EI_ATTINY24
@@ -1213,12 +1210,9 @@ void disableInterrupt (uint8_t interruptDesignator) {
 /*{{{*/
 #if defined ARDUINO_328
   if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 2 && arduinoPin != 3) ) {
-#elif defined ARDUINO_AVR_ENVIRODIY_MAYFLY || defined ARDUINO_AVR_SODAQ_MBILI
-  if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 10 && arduinoPin != 2 &&
-                                                      arduinoPin != 3) ) {
 #elif defined MIGHTY1284
-  if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 2 && arduinoPin != 10 &&
-                                                      arduinoPin != 11) ) {
+if ( (interruptDesignator & PINCHANGEINTERRUPT) ||
+   (arduinoPin != ARDUINO_PIN_B2 && arduinoPin != ARDUINO_PIN_D2 && arduinoPin != ARDUINO_PIN_D3) ) {
 #elif defined EI_ATTINY24
   if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 8) ) {
 #elif defined EI_ATTINY25

--- a/EnableInterrupt.h
+++ b/EnableInterrupt.h
@@ -14,7 +14,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/ 
+*/
 
 // Many definitions in /usr/avr/include/avr/io.h
 
@@ -37,7 +37,7 @@
 // Arduino Due (not Duemilanove) and Zero macros. Easy-peasy.
 // Zero uses the __SAMD21G18A__ processor macro (2015-10-13) but we will use this handy macro, to
 // avoid breaking the library over tiny changes.
-#if defined __SAM3U4E__ || defined __SAM3X8E__ || defined __SAM3X8H__ || defined ARDUINO_SAMD_ZERO/*{{{*/
+#if defined __SAM3U4E__ || defined __SAM3X8E__ || defined __SAM3X8H__ || defined __SAMD21G18A__ || defined ARDUINO_SAMD_ZERO/*{{{*/
 #ifdef NEEDFORSPEED
 #error Due and Zero are already fast; the NEEDFORSPEED definition does not make sense on it.
 #endif
@@ -49,7 +49,7 @@
 /* enableInterrupt- Sets up an interrupt on a selected Arduino pin.
  * or
  * enableInterruptFast- When used with the NEEDFORSPEED macro, sets up an interrupt on a selected Arduino pin.
- * 
+ *
  * Usage:
  * enableInterrupt(uint8_t pinNumber, void (*userFunction)(void), uint8_t mode);
  * or
@@ -78,11 +78,11 @@
  * to specify that you want to use a Pin Change Interrupt type of interrupt on those pins that
  * support both Pin Change and External Interrupts. Otherwise, the library will choose whatever
  * interrupt type (External, or Pin Change) normally applies to that pin, with priority to
- * External Interrupt. 
+ * External Interrupt.
  *
  * The interruptDesignator is required because on the ATmega328 processor pins 2 and 3 support
  * ''either'' pin change or * external interrupts. On 644/1284-based systems, pin change interrupts
- * are supported on all pins and external interruptsare supported on pins 2, 10, and 11. 
+ * are supported on all pins and external interruptsare supported on pins 2, 10, and 11.
  * Otherwise, each pin only supports a single type of interrupt and the
  * PINCHANGEINTERRUPT scheme changes nothing. This means you can ignore this whole discussion
  * for ATmega2560- or ATmega32U4-based Arduinos. You can probably safely ignore it for
@@ -562,7 +562,7 @@ static volatile uint8_t portSnapshotK;
 #define ARDUINO_PIN_D3 1
 #define ARDUINO_PIN_E6 7
 
-/* To derive this list: 
+/* To derive this list:
    sed -n -e '1,/digital_pin_to_port_PGM/d' -e '/^}/,$d' -e '/P/p' \
        /usr/share/arduino/hardware/arduino/variants/leonardo/pins_arduino.h | \
        awk '{print "  ", $5 ", // " $5 "  pin: " $3}'
@@ -687,6 +687,26 @@ static volatile uint8_t portSnapshotB;
 #define ARDUINO_PIN_D6 14
 #define ARDUINO_PIN_D7 15
 
+// For boards with the 44 pin options:  vectors B & D are reversed
+#if defined ARDUINO_AVR_ENVIRODIY_MAYFLY || defined ARDUINO_AVR_SODAQ_MBILI
+#define ARDUINO_PIN_D0 0
+#define ARDUINO_PIN_D1 1
+#define ARDUINO_PIN_D2 2
+#define ARDUINO_PIN_D3 3
+#define ARDUINO_PIN_D4 4
+#define ARDUINO_PIN_D5 5
+#define ARDUINO_PIN_D6 6
+#define ARDUINO_PIN_D7 7
+#define ARDUINO_PIN_B0 8
+#define ARDUINO_PIN_B1 9
+#define ARDUINO_PIN_B2 10
+#define ARDUINO_PIN_B3 11
+#define ARDUINO_PIN_B4 12
+#define ARDUINO_PIN_B5 13
+#define ARDUINO_PIN_B6 14
+#define ARDUINO_PIN_B7 15
+#endif
+
 const uint8_t PROGMEM digital_pin_to_port_bit_number_PGM[] = {
   0, // 0 == port B, 0
   1,
@@ -776,7 +796,7 @@ static volatile uint8_t portSnapshotB;
 volatile uint8_t risingPinsPORTC=0;
 volatile uint8_t fallingPinsPORTC=0;
 static volatile uint8_t portSnapshotC;
-#endif 
+#endif
 
 #ifndef EI_NOTPORTD
 volatile uint8_t risingPinsPORTD=0;
@@ -987,7 +1007,7 @@ static volatile uint8_t portSnapshotB;
 #define EI_printPSTR(x) EI_SerialPrint_P(PSTR(x))
 void EI_SerialPrint_P(const char *str) {
   for (uint8_t c; (c = pgm_read_byte(str)); str++) Serial.write(c);
-} 
+}
 #endif
 
 
@@ -1017,6 +1037,9 @@ void enableInterrupt(uint8_t interruptDesignator, interruptFunctionType userFunc
 /*{{{*/
 #if defined ARDUINO_328
   if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 2 && arduinoPin != 3) ) {
+#elif defined MIGHTY1284 && (defined ARDUINO_AVR_ENVIRODIY_MAYFLY || defined ARDUINO_AVR_SODAQ_MBILI)
+  if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 10 && arduinoPin != 2 &&
+                                                      arduinoPin != 3) ) {
 #elif defined MIGHTY1284
   if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 2 && arduinoPin != 10 &&
                                                       arduinoPin != 11) ) {
@@ -1189,6 +1212,9 @@ void disableInterrupt (uint8_t interruptDesignator) {
 /*{{{*/
 #if defined ARDUINO_328
   if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 2 && arduinoPin != 3) ) {
+#elif defined MIGHTY1284 && (defined ARDUINO_AVR_ENVIRODIY_MAYFLY || defined ARDUINO_AVR_SODAQ_MBILI)
+  if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 10 && arduinoPin != 2 &&
+                                                      arduinoPin != 3) ) {
 #elif defined MIGHTY1284
   if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 2 && arduinoPin != 10 &&
                                                       arduinoPin != 11) ) {

--- a/EnableInterrupt.h
+++ b/EnableInterrupt.h
@@ -675,7 +675,7 @@ static volatile uint8_t portSnapshotB;
 #if defined ARDUINO_AVR_ENVIRODIY_MAYFLY || defined ARDUINO_AVR_SODAQ_MBILI
 #define ARDUINO_PIN_B0 8
 #define ARDUINO_PIN_B1 9
-#define ARDUINO_PIN_B2 10
+#define ARDUINO_PIN_B2 10  // INT2
 #define ARDUINO_PIN_B3 11
 #define ARDUINO_PIN_B4 12
 #define ARDUINO_PIN_B5 13
@@ -683,8 +683,8 @@ static volatile uint8_t portSnapshotB;
 #define ARDUINO_PIN_B7 15
 #define ARDUINO_PIN_D0 0
 #define ARDUINO_PIN_D1 1
-#define ARDUINO_PIN_D2 2
-#define ARDUINO_PIN_D3 3
+#define ARDUINO_PIN_D2 2  // INT0
+#define ARDUINO_PIN_D3 3  // INT1
 #define ARDUINO_PIN_D4 4
 #define ARDUINO_PIN_D5 5
 #define ARDUINO_PIN_D6 6
@@ -692,7 +692,7 @@ static volatile uint8_t portSnapshotB;
 #else
 #define ARDUINO_PIN_B0 0
 #define ARDUINO_PIN_B1 1
-#define ARDUINO_PIN_B2 2
+#define ARDUINO_PIN_B2 2  // INT2
 #define ARDUINO_PIN_B3 3
 #define ARDUINO_PIN_B4 4
 #define ARDUINO_PIN_B5 5
@@ -700,8 +700,8 @@ static volatile uint8_t portSnapshotB;
 #define ARDUINO_PIN_B7 7
 #define ARDUINO_PIN_D0 8
 #define ARDUINO_PIN_D1 9
-#define ARDUINO_PIN_D2 10
-#define ARDUINO_PIN_D3 11
+#define ARDUINO_PIN_D2 10  // INT0
+#define ARDUINO_PIN_D3 11  // INT1
 #define ARDUINO_PIN_D4 12
 #define ARDUINO_PIN_D5 13
 #define ARDUINO_PIN_D6 14
@@ -1325,7 +1325,9 @@ ISR(INT0_vect) {/*{{{*/
   externalFunctionPointer();
 #endif
 #else
-#if defined MIGHTY1284
+#if defined ARDUINO_AVR_ENVIRODIY_MAYFLY || defined ARDUINO_AVR_SODAQ_MBILI
+  INTERRUPT_FLAG_PIN2++;
+#elif defined MIGHTY1284
   INTERRUPT_FLAG_PIN10++;
 #endif
 #if defined ARDUINO_MEGA
@@ -1376,7 +1378,9 @@ ISR(INT1_vect) {/*{{{*/
 #endif // EI_ARDUINO_INTERRUPTED_PIN
   (*functionPointerArrayEXTERNAL[1])();
 #else
-#if defined MIGHTY1284
+#if defined ARDUINO_AVR_ENVIRODIY_MAYFLY || defined ARDUINO_AVR_SODAQ_MBILI
+  INTERRUPT_FLAG_PIN3++;
+#elif defined MIGHTY1284
   INTERRUPT_FLAG_PIN11++;
 #endif
 #if defined ARDUINO_MEGA
@@ -1414,7 +1418,9 @@ ISR(INT2_vect) {/*{{{*/
 #endif // EI_ARDUINO_INTERRUPTED_PIN
   (*functionPointerArrayEXTERNAL[2])();
 #else
-#if defined MIGHTY1284
+#if defined ARDUINO_AVR_ENVIRODIY_MAYFLY || defined ARDUINO_AVR_SODAQ_MBILI
+  INTERRUPT_FLAG_PIN10++;
+#elif defined MIGHTY1284
   INTERRUPT_FLAG_PIN2++;
 #endif
 #if defined ARDUINO_MEGA

--- a/EnableInterrupt.h
+++ b/EnableInterrupt.h
@@ -37,7 +37,7 @@
 // Arduino Due (not Duemilanove) and Zero macros. Easy-peasy.
 // Zero uses the __SAMD21G18A__ processor macro (2015-10-13) but we will use this handy macro, to
 // avoid breaking the library over tiny changes.
-#if defined __SAM3U4E__ || defined __SAM3X8E__ || defined __SAM3X8H__ || defined ARDUINO_SAMD_ZERO || defined __SAMD21G18A__/*{{{*/
+#if defined __SAM3U4E__ || defined __SAM3X8E__ || defined __SAM3X8H__ || defined ARDUINO_SAMD_ZERO || defined __SAMD21G18A__  || defined __SAMD21J18A__ /*{{{*/
 #ifdef NEEDFORSPEED
 #error Due and Zero are already fast; the NEEDFORSPEED definition does not make sense on it.
 #endif
@@ -1211,7 +1211,7 @@ void disableInterrupt (uint8_t interruptDesignator) {
 #if defined ARDUINO_328
   if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 2 && arduinoPin != 3) ) {
 #elif defined MIGHTY1284
-if ( (interruptDesignator & PINCHANGEINTERRUPT) ||
+  if ( (interruptDesignator & PINCHANGEINTERRUPT) ||
    (arduinoPin != ARDUINO_PIN_B2 && arduinoPin != ARDUINO_PIN_D2 && arduinoPin != ARDUINO_PIN_D3) ) {
 #elif defined EI_ATTINY24
   if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 8) ) {

--- a/EnableInterrupt.h
+++ b/EnableInterrupt.h
@@ -19,7 +19,7 @@
 // Many definitions in /usr/avr/include/avr/io.h
 
 #ifndef EnableInterrupt_h
-#pragma message("NOTICE: *** EnableInterrupt library PRIOR TO version 0.9.6. This is not a problem. Keep calm, and carry on. ***")
+#pragma message("NOTICE: *** EnableInterrupt library PRIOR TO version 0.9.8. This is not a problem. Keep calm, and carry on. ***")
 #define EnableInterrupt_h
 #include <Arduino.h>
 
@@ -37,7 +37,7 @@
 // Arduino Due (not Duemilanove) and Zero macros. Easy-peasy.
 // Zero uses the __SAMD21G18A__ processor macro (2015-10-13) but we will use this handy macro, to
 // avoid breaking the library over tiny changes.
-#if defined __SAM3U4E__ || defined __SAM3X8E__ || defined __SAM3X8H__ || defined __SAMD21G18A__ || defined ARDUINO_SAMD_ZERO/*{{{*/
+#if defined __SAM3U4E__ || defined __SAM3X8E__ || defined __SAM3X8H__ || defined ARDUINO_SAMD_ZERO/*{{{*/
 #ifdef NEEDFORSPEED
 #error Due and Zero are already fast; the NEEDFORSPEED definition does not make sense on it.
 #endif
@@ -662,14 +662,6 @@ static volatile uint8_t portSnapshotB;
 #define ARDUINO_PIN_A5 29
 #define ARDUINO_PIN_A6 30
 #define ARDUINO_PIN_A7 31
-#define ARDUINO_PIN_B0 0
-#define ARDUINO_PIN_B1 1
-#define ARDUINO_PIN_B2 2
-#define ARDUINO_PIN_B3 3
-#define ARDUINO_PIN_B4 4
-#define ARDUINO_PIN_B5 5
-#define ARDUINO_PIN_B6 6
-#define ARDUINO_PIN_B7 7
 #define ARDUINO_PIN_C0 16
 #define ARDUINO_PIN_C1 17
 #define ARDUINO_PIN_C2 18
@@ -678,25 +670,9 @@ static volatile uint8_t portSnapshotB;
 #define ARDUINO_PIN_C5 21
 #define ARDUINO_PIN_C6 22
 #define ARDUINO_PIN_C7 23
-#define ARDUINO_PIN_D0 8
-#define ARDUINO_PIN_D1 9
-#define ARDUINO_PIN_D2 10
-#define ARDUINO_PIN_D3 11
-#define ARDUINO_PIN_D4 12
-#define ARDUINO_PIN_D5 13
-#define ARDUINO_PIN_D6 14
-#define ARDUINO_PIN_D7 15
 
 // For boards with the 44 pin options:  vectors B & D are reversed
 #if defined ARDUINO_AVR_ENVIRODIY_MAYFLY || defined ARDUINO_AVR_SODAQ_MBILI
-#define ARDUINO_PIN_D0 0
-#define ARDUINO_PIN_D1 1
-#define ARDUINO_PIN_D2 2
-#define ARDUINO_PIN_D3 3
-#define ARDUINO_PIN_D4 4
-#define ARDUINO_PIN_D5 5
-#define ARDUINO_PIN_D6 6
-#define ARDUINO_PIN_D7 7
 #define ARDUINO_PIN_B0 8
 #define ARDUINO_PIN_B1 9
 #define ARDUINO_PIN_B2 10
@@ -705,6 +681,31 @@ static volatile uint8_t portSnapshotB;
 #define ARDUINO_PIN_B5 13
 #define ARDUINO_PIN_B6 14
 #define ARDUINO_PIN_B7 15
+#define ARDUINO_PIN_D0 0
+#define ARDUINO_PIN_D1 1
+#define ARDUINO_PIN_D2 2
+#define ARDUINO_PIN_D3 3
+#define ARDUINO_PIN_D4 4
+#define ARDUINO_PIN_D5 5
+#define ARDUINO_PIN_D6 6
+#define ARDUINO_PIN_D7 7
+#else
+#define ARDUINO_PIN_B0 0
+#define ARDUINO_PIN_B1 1
+#define ARDUINO_PIN_B2 2
+#define ARDUINO_PIN_B3 3
+#define ARDUINO_PIN_B4 4
+#define ARDUINO_PIN_B5 5
+#define ARDUINO_PIN_B6 6
+#define ARDUINO_PIN_B7 7
+#define ARDUINO_PIN_D0 8
+#define ARDUINO_PIN_D1 9
+#define ARDUINO_PIN_D2 10
+#define ARDUINO_PIN_D3 11
+#define ARDUINO_PIN_D4 12
+#define ARDUINO_PIN_D5 13
+#define ARDUINO_PIN_D6 14
+#define ARDUINO_PIN_D7 15
 #endif
 
 const uint8_t PROGMEM digital_pin_to_port_bit_number_PGM[] = {
@@ -1037,7 +1038,7 @@ void enableInterrupt(uint8_t interruptDesignator, interruptFunctionType userFunc
 /*{{{*/
 #if defined ARDUINO_328
   if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 2 && arduinoPin != 3) ) {
-#elif defined MIGHTY1284 && (defined ARDUINO_AVR_ENVIRODIY_MAYFLY || defined ARDUINO_AVR_SODAQ_MBILI)
+#elif defined ARDUINO_AVR_ENVIRODIY_MAYFLY || defined ARDUINO_AVR_SODAQ_MBILI
   if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 10 && arduinoPin != 2 &&
                                                       arduinoPin != 3) ) {
 #elif defined MIGHTY1284
@@ -1212,7 +1213,7 @@ void disableInterrupt (uint8_t interruptDesignator) {
 /*{{{*/
 #if defined ARDUINO_328
   if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 2 && arduinoPin != 3) ) {
-#elif defined MIGHTY1284 && (defined ARDUINO_AVR_ENVIRODIY_MAYFLY || defined ARDUINO_AVR_SODAQ_MBILI)
+#elif defined ARDUINO_AVR_ENVIRODIY_MAYFLY || defined ARDUINO_AVR_SODAQ_MBILI
   if ( (interruptDesignator & PINCHANGEINTERRUPT) || (arduinoPin != 10 && arduinoPin != 2 &&
                                                       arduinoPin != 3) ) {
 #elif defined MIGHTY1284

--- a/EnableInterrupt.h
+++ b/EnableInterrupt.h
@@ -37,7 +37,7 @@
 // Arduino Due (not Duemilanove) and Zero macros. Easy-peasy.
 // Zero uses the __SAMD21G18A__ processor macro (2015-10-13) but we will use this handy macro, to
 // avoid breaking the library over tiny changes.
-#if defined __SAM3U4E__ || defined __SAM3X8E__ || defined __SAM3X8H__ || defined ARDUINO_SAMD_ZERO/*{{{*/
+#if defined __SAM3U4E__ || defined __SAM3X8E__ || defined __SAM3X8H__ || defined ARDUINO_SAMD_ZERO || defined __SAMD21G18A__/*{{{*/
 #ifdef NEEDFORSPEED
 #error Due and Zero are already fast; the NEEDFORSPEED definition does not make sense on it.
 #endif

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "EnableInterrupt",
-  "version": "0.9.6",
+  "version": "0.9.8",
   "frameworks": "Arduino",
   "keywords": "interrupt, interrupts, pin, pins",
   "description": "Assign an interrupt to any supported pin on all Arduinos, plus ATtiny 84/85 and ATmega 644/1284.",

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "EnableInterrupt",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "frameworks": "Arduino",
   "keywords": "interrupt, interrupts, pin, pins",
   "description": "Assign an interrupt to any supported pin on all Arduinos, plus ATtiny 84/85 and ATmega 644/1284.",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EnableInterrupt
-version=0.9.5
+version=0.9.6
 author=Mike "GreyGnome" Schwager <mschwage@gmail.com>
 maintainer=Mike "GreyGnome" Schwager <mschwage@gmail.com>
 sentence=Assign an interrupt to any supported pin on all Arduinos, plus ATtiny 84/85 and ATmega 644/1284.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EnableInterrupt
-version=0.9.6
+version=0.9.8
 author=Mike "GreyGnome" Schwager <mschwage@gmail.com>
 maintainer=Mike "GreyGnome" Schwager <mschwage@gmail.com>
 sentence=Assign an interrupt to any supported pin on all Arduinos, plus ATtiny 84/85 and ATmega 644/1284.

--- a/utility/ei_External1284.h
+++ b/utility/ei_External1284.h
@@ -42,21 +42,21 @@ switch (arduinoPin) {
 
 #ifdef EI_SECTION_DISABLEEXTERNAL
 #ifndef EI_NOTINT0
-if (arduinoPin == 10) {
+if (arduinoPin == ARDUINO_PIN_D2) {  // INT0
   EIMSK &= ~_BV(0);
   EICRA &= (~_BV(0) & ~_BV(1));
   EIFR  |= _BV(0); // using a clue from the ATmega2560 datasheet.
 }
 #endif
 #ifndef EI_NOTINT1
-if (arduinoPin == 11) {
+if (arduinoPin == ARDUINO_PIN_D3) {  // INT1
   EIMSK &= ~_BV(1);
   EICRA &= (~_BV(2) & ~_BV(3));
   EIFR  |= _BV(1); // using a clue from the ATmega2560 datasheet.
 }
 #endif
 #ifndef EI_NOTINT2
-if (arduinoPin == 2) {
+if (arduinoPin == ARDUINO_PIN_B2) {  // INT2
   EIMSK &= ~_BV(2);
   EICRA &= (~_BV(4) & ~_BV(5));
   EIFR  |= _BV(2); // using a clue from the ATmega2560 datasheet.

--- a/utility/ei_External1284.h
+++ b/utility/ei_External1284.h
@@ -2,7 +2,7 @@
 #ifdef EI_SECTION_ENABLEEXTERNAL
 switch (arduinoPin) {
 #ifndef EI_NOTINT0
-  case 10 : // INT0
+  case ARDUINO_PIN_D2 : // INT0
     EIMSK &= ~_BV(0);
 #ifndef NEEDFORSPEED
     functionPointerArrayEXTERNAL[0] = userFunction;
@@ -14,7 +14,7 @@ switch (arduinoPin) {
     break;
 #endif
 #ifndef EI_NOTINT1
-  case 11 : // INT1
+  case ARDUINO_PIN_D3 : // INT1
     EIMSK &= ~_BV(1);
 #ifndef NEEDFORSPEED
     functionPointerArrayEXTERNAL[1] = userFunction;
@@ -26,7 +26,7 @@ switch (arduinoPin) {
     break;
 #endif
 #ifndef EI_NOTINT2
-  case 2 : // INT2
+  case ARDUINO_PIN_B2 : // INT2
     EIMSK &= ~_BV(2);
 #ifndef NEEDFORSPEED
     functionPointerArrayEXTERNAL[2] = userFunction;

--- a/utility/ei_External1284.h
+++ b/utility/ei_External1284.h
@@ -2,7 +2,7 @@
 #ifdef EI_SECTION_ENABLEEXTERNAL
 switch (arduinoPin) {
 #ifndef EI_NOTINT0
-  case ARDUINO_PIN_D2 : // INT0
+  case ARDUINO_PIN_D2 : // INT0  (Either 2 or 10)
     EIMSK &= ~_BV(0);
 #ifndef NEEDFORSPEED
     functionPointerArrayEXTERNAL[0] = userFunction;
@@ -14,7 +14,7 @@ switch (arduinoPin) {
     break;
 #endif
 #ifndef EI_NOTINT1
-  case ARDUINO_PIN_D3 : // INT1
+  case ARDUINO_PIN_D3 : // INT1  (Either 3 or 11)
     EIMSK &= ~_BV(1);
 #ifndef NEEDFORSPEED
     functionPointerArrayEXTERNAL[1] = userFunction;
@@ -26,7 +26,7 @@ switch (arduinoPin) {
     break;
 #endif
 #ifndef EI_NOTINT2
-  case ARDUINO_PIN_B2 : // INT2
+  case ARDUINO_PIN_B2 : // INT2  (Either 10 or 2)
     EIMSK &= ~_BV(2);
 #ifndef NEEDFORSPEED
     functionPointerArrayEXTERNAL[2] = userFunction;
@@ -42,21 +42,21 @@ switch (arduinoPin) {
 
 #ifdef EI_SECTION_DISABLEEXTERNAL
 #ifndef EI_NOTINT0
-if (arduinoPin == ARDUINO_PIN_D2) {  // INT0
+if (arduinoPin == ARDUINO_PIN_D2) {  // INT0  (Either 2 or 10)
   EIMSK &= ~_BV(0);
   EICRA &= (~_BV(0) & ~_BV(1));
   EIFR  |= _BV(0); // using a clue from the ATmega2560 datasheet.
 }
 #endif
 #ifndef EI_NOTINT1
-if (arduinoPin == ARDUINO_PIN_D3) {  // INT1
+if (arduinoPin == ARDUINO_PIN_D3) {  // INT1  (Either 3 or 11)
   EIMSK &= ~_BV(1);
   EICRA &= (~_BV(2) & ~_BV(3));
   EIFR  |= _BV(1); // using a clue from the ATmega2560 datasheet.
 }
 #endif
 #ifndef EI_NOTINT2
-if (arduinoPin == ARDUINO_PIN_B2) {  // INT2
+if (arduinoPin == ARDUINO_PIN_B2) {  // INT2  (Either 10 or 2)
   EIMSK &= ~_BV(2);
   EICRA &= (~_BV(4) & ~_BV(5));
   EIFR  |= _BV(2); // using a clue from the ATmega2560 datasheet.

--- a/utility/ei_portb_speed.h
+++ b/utility/ei_portb_speed.h
@@ -23,7 +23,7 @@
 #if defined INTERRUPT_FLAG_PIN15
   if (interruptMask & _BV(7)) INTERRUPT_FLAG_PIN15++;
 #endif
-#else if defined MIGHTY1284
+#elif defined MIGHTY1284
 #ifdef INTERRUPT_FLAG_PIN0
   if (interruptMask & _BV(0)) INTERRUPT_FLAG_PIN0++;
 #endif

--- a/utility/ei_portb_speed.h
+++ b/utility/ei_portb_speed.h
@@ -1,4 +1,29 @@
-#if defined MIGHTY1284
+#if defined ARDUINO_AVR_ENVIRODIY_MAYFLY || defined ARDUINO_AVR_SODAQ_MBILI
+#if defined INTERRUPT_FLAG_PIN8
+  if (interruptMask & _BV(0)) INTERRUPT_FLAG_PIN8++;
+#endif
+#if defined INTERRUPT_FLAG_PIN9
+  if (interruptMask & _BV(1)) INTERRUPT_FLAG_PIN9++;
+#endif
+#if defined INTERRUPT_FLAG_PIN10
+  if (interruptMask & _BV(2)) INTERRUPT_FLAG_PIN10++;
+#endif
+#if defined INTERRUPT_FLAG_PIN11
+  if (interruptMask & _BV(3)) INTERRUPT_FLAG_PIN11++;
+#endif
+#if defined INTERRUPT_FLAG_PIN12
+  if (interruptMask & _BV(4)) INTERRUPT_FLAG_PIN12++;
+#endif
+#if defined INTERRUPT_FLAG_PIN13
+  if (interruptMask & _BV(5)) INTERRUPT_FLAG_PIN13++;
+#endif
+#if defined INTERRUPT_FLAG_PIN14
+  if (interruptMask & _BV(6)) INTERRUPT_FLAG_PIN14++;
+#endif
+#if defined INTERRUPT_FLAG_PIN15
+  if (interruptMask & _BV(7)) INTERRUPT_FLAG_PIN15++;
+#endif
+#else if defined MIGHTY1284
 #ifdef INTERRUPT_FLAG_PIN0
   if (interruptMask & _BV(0)) INTERRUPT_FLAG_PIN0++;
 #endif

--- a/utility/ei_portd_speed.h
+++ b/utility/ei_portd_speed.h
@@ -1,4 +1,29 @@
-#if defined MIGHTY1284
+#if defined ARDUINO_AVR_ENVIRODIY_MAYFLY || defined ARDUINO_AVR_SODAQ_MBILI
+#ifdef INTERRUPT_FLAG_PIN0
+  if (interruptMask & _BV(0)) INTERRUPT_FLAG_PIN0++;
+#endif
+#ifdef INTERRUPT_FLAG_PIN1
+  if (interruptMask & _BV(1)) INTERRUPT_FLAG_PIN1++;
+#endif
+#ifdef INTERRUPT_FLAG_PIN2
+  if (interruptMask & _BV(2)) INTERRUPT_FLAG_PIN2++;
+#endif
+#ifdef INTERRUPT_FLAG_PIN3
+  if (interruptMask & _BV(3)) INTERRUPT_FLAG_PIN3++;
+#endif
+#ifdef INTERRUPT_FLAG_PIN4
+  if (interruptMask & _BV(4)) INTERRUPT_FLAG_PIN4++;
+#endif
+#ifdef INTERRUPT_FLAG_PIN5
+  if (interruptMask & _BV(5)) INTERRUPT_FLAG_PIN5++;
+#endif
+#ifdef INTERRUPT_FLAG_PIN6
+  if (interruptMask & _BV(6)) INTERRUPT_FLAG_PIN6++;
+#endif
+#ifdef INTERRUPT_FLAG_PIN7
+  if (interruptMask & _BV(7)) INTERRUPT_FLAG_PIN7++;
+#endif
+#else if defined MIGHTY1284
 #if defined INTERRUPT_FLAG_PIN8
   if (interruptMask & _BV(0)) INTERRUPT_FLAG_PIN8++;
 #endif

--- a/utility/ei_portd_speed.h
+++ b/utility/ei_portd_speed.h
@@ -23,7 +23,7 @@
 #ifdef INTERRUPT_FLAG_PIN7
   if (interruptMask & _BV(7)) INTERRUPT_FLAG_PIN7++;
 #endif
-#else if defined MIGHTY1284
+#elif defined MIGHTY1284
 #if defined INTERRUPT_FLAG_PIN8
   if (interruptMask & _BV(0)) INTERRUPT_FLAG_PIN8++;
 #endif


### PR DESCRIPTION
Added support for these two AtMega1284p boards, which reverse the digital pin number assignments of vectors B&D from the Mighty1284p configuration.