### PR TITLE
support for atmega2561 and atmega1281 (MegaCore 64pin variants)

### DIFF
--- a/EnableInterrupt.h
+++ b/EnableInterrupt.h
@@ -82,7 +82,7 @@
  *
  * The interruptDesignator is required because on the ATmega328 processor pins 2 and 3 support
  * ''either'' pin change or * external interrupts. On 644/1284-based systems, pin change interrupts
- * are supported on all pins and external interruptsare supported on pins 2, 10, and 11.
+ * are supported on all pins and external interrupts are supported on pins 2, 10, and 11.
  * Otherwise, each pin only supports a single type of interrupt and the
  * PINCHANGEINTERRUPT scheme changes nothing. This means you can ignore this whole discussion
  * for ATmega2560- or ATmega32U4-based Arduinos. You can probably safely ignore it for
@@ -304,11 +304,10 @@ static volatile uint8_t portSnapshotD;
 #define PORTC_VECT PCINT1_vect
 #define PORTD_VECT PCINT2_vect/*}}}*/
 
-/* MEGA SERIES ************************************************************************/
-/* MEGA SERIES ************************************************************************/
-/* MEGA SERIES ************************************************************************/
-#elif defined __AVR_ATmega640__ || defined __AVR_ATmega2560__ || defined __AVR_ATmega1280__ || \
-  defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+/* MEGA2560/1280/640 SERIES ************************************************************************/
+/* MEGA2560/1280/640 SERIES ************************************************************************/
+/* MEGA2560/1280/640 SERIES ************************************************************************/
+#elif defined __AVR_ATmega640__ || defined __AVR_ATmega2560__ || defined __AVR_ATmega1280__
 #define ARDUINO_MEGA /*{{{*/
 #define EI_NOTPORTA
 #define EI_NOTPORTC
@@ -527,6 +526,124 @@ static volatile uint8_t portSnapshotK;
 #define PORTB_VECT PCINT0_vect
 #define PORTJ_VECT PCINT1_vect
 #define PORTK_VECT PCINT2_vect
+/*}}}*/
+
+/* MEGA2561/1281 SERIES ************************************************************************/
+/* MEGA2561/1281 SERIES ************************************************************************/
+/* MEGA2561/1281 SERIES ************************************************************************/
+#elif defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+#define ARDUINO_MEGA /*{{{*/
+#define EI_NOTPORTA
+#define EI_NOTPORTC
+#define EI_NOTPORTD
+#define EI_NOTPORTJ
+#define EI_NOTPORTK /*}}}*/
+
+#if defined EI_NOTPINCHANGE/*{{{*/
+#ifndef EI_NOTPORTB
+#define EI_NOTPORTB
+#endif
+#endif
+
+#ifndef NEEDFORSPEED
+// Pin change interrupts
+#define ARDUINO_PIN_B0 8
+#define ARDUINO_PIN_B1 9
+#define ARDUINO_PIN_B2 10
+#define ARDUINO_PIN_B3 11
+#define ARDUINO_PIN_B4 12
+#define ARDUINO_PIN_B5 13
+#define ARDUINO_PIN_B6 14
+#define ARDUINO_PIN_B7 15
+
+const uint8_t PROGMEM digital_pin_to_port_bit_number_PGM[] = {
+  0, // PE0  pin: 0
+  1, // PE1  pin: 1
+  2, // PE2  pin: 2
+  3, // PE3  pin: 3
+  4, // PE4  pin: 4
+  5, // PE5  pin: 5
+  6, // PE6  pin: 6
+  7, // PE7  pin: 7
+  0, // PB0  pin: 8
+  1, // PB1  pin: 9
+  2, // PB2  pin: 10
+  3, // PB3  pin: 11
+  4, // PB4  pin: 12
+  5, // PB5  pin: 13
+  6, // PB6  pin: 14
+  7, // PB7  pin: 15
+  3, // PG3  pin: 16
+  4, // PG4  pin: 17
+  0, // PD0  pin: 18
+  1, // PD1  pin: 19
+  2, // PD2  pin: 20
+  3, // PD3  pin: 21
+  4, // PD4  pin: 22
+  5, // PD5  pin: 23
+  6, // PD6  pin: 24
+  7, // PD7  pin: 25
+  0, // PG0  pin: 26
+  1, // PG1  pin: 27
+  0, // PC0  pin: 28
+  1, // PC1  pin: 29
+  2, // PC2  pin: 30
+  3, // PC3  pin: 31
+  4, // PC4  pin: 32
+  5, // PC5  pin: 33
+  6, // PC6  pin: 34
+  7, // PC7  pin: 35
+  2, // PG2  pin: 36
+  7, // PA7  pin: 37
+  6, // PA6  pin: 38
+  5, // PA5  pin: 39
+  4, // PA4  pin: 40
+  3, // PA3  pin: 41
+  2, // PA2  pin: 42
+  1, // PA1  pin: 43
+  0, // PA0  pin: 44
+  0, // PF0  pin: 45
+  1, // PF1  pin: 46
+  2, // PF2  pin: 47
+  3, // PF3  pin: 48
+  4, // PF4  pin: 49
+  5, // PF5  pin: 50
+  6, // PF6  pin: 51
+  7, // PF7  pin: 52
+  5  // PG5  pin: 53
+};
+
+#if ! defined(EI_NOTEXTERNAL) && ! defined(EI_NOTINT0) && ! defined(EI_NOTINT1) && ! defined(EI_NOTINT2) && ! defined(EI_NOTINT3) && ! defined(EI_NOTINT4) && ! defined(EI_NOTINT5) && ! defined(EI_NOTINT6) && ! defined(EI_NOTINT7)
+interruptFunctionType functionPointerArrayEXTERNAL[8];
+#endif
+
+#ifndef EI_NOTPORTB
+struct functionPointersPortB {
+  interruptFunctionType pinZero;
+  interruptFunctionType pinOne;
+  interruptFunctionType pinTwo;
+  interruptFunctionType pinThree;
+  interruptFunctionType pinFour;
+  interruptFunctionType pinFive;
+  interruptFunctionType pinSix;
+  interruptFunctionType pinSeven;
+};
+typedef struct functionPointersPortB functionPointersPortB;
+
+functionPointersPortB portBFunctions = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };
+#endif
+
+#endif // ifndef NEEDFORSPEED
+
+// For Pin Change Interrupts; since we're duplicating FALLING and RISING in software,
+// we have to know how we were defined.
+#ifndef EI_NOTPORTB
+volatile uint8_t risingPinsPORTB=0;
+volatile uint8_t fallingPinsPORTB=0;
+static volatile uint8_t portSnapshotB;
+#endif
+
+#define PORTB_VECT PCINT0_vect
 /*}}}*/
 
 /* LEONARDO ***************************************************************************/
@@ -1140,6 +1257,7 @@ void enableInterrupt(uint8_t interruptDesignator, interruptFunctionType userFunc
       portNumber=pgm_read_byte(&digital_pin_to_port_PGM[arduinoPin]);
     }
 #elif defined ARDUINO_MEGA
+#if defined __AVR_ATmega640__ || defined __AVR_ATmega2560__ || defined __AVR_ATmega1280__
   // NOTE: PJ2-6 and PE6 & 7 are not exposed on the Arduino, but they are supported here
   // for software interrupts and support of non-Arduino platforms which expose more pins.
   // PJ2-6 are called pins 70-74, PE6 is pin 75, PE7 is pin 76.
@@ -1153,6 +1271,11 @@ void enableInterrupt(uint8_t interruptDesignator, interruptFunctionType userFunc
       portMask=pgm_read_byte(&digital_pin_to_bit_mask_PGM[arduinoPin]);
       portNumber=pgm_read_byte(&digital_pin_to_port_PGM[arduinoPin]);
     }
+#elif defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  if (!(((arduinoPin >= 4) && (arduinoPin <= 7)) || ((arduinoPin >= 18) && (arduinoPin <=21)))) {
+      portMask=pgm_read_byte(&digital_pin_to_bit_mask_PGM[arduinoPin]);
+      portNumber=pgm_read_byte(&digital_pin_to_port_PGM[arduinoPin]);
+#endif
 #else
 #error Unsupported Arduino platform
 #endif

--- a/README.md
+++ b/README.md
@@ -295,6 +295,45 @@ the library's code and thus is not supported by this library.  It is the same
 pin the Arduino uses to upload sketches, and it is connected to the FT232RL
 USB-to-Serial chip (ATmega16U2 on the R3).
 
+### ATmega2561/1281 (MegaCore) Support
+
+<pre>
+External Interrupts ------------------------------------------------------------
+The following External Interrupts are available on the Arduino/MegaCore:
+MegaCore           
+  Pin  PORT INT  ATmega2561/1281 pin
+  18     PD0  0     25
+  19     PD1  1     26
+  20     PD2  2     27
+  21     PD3  3     28
+   4     PE4  4      6
+   5     PE5  5      7
+   6     PE6  6      8
+   7     PE7  7      9
+
+
+Pin Change Interrupts ----------------------------------------------------------
+
+ATMEGA2561/1281 (MegaCore) Pin Change Interrupts
+MegaCore
+ Pin      PORT   PCINT
+  8/SS     PB0     0
+  9/SCK    PB1     1
+  10/MOSI  PB2     2
+  11/MISO  PB3     3
+  12       PB4     4
+  13       PB5     5
+  14       PB6     6
+  15       PB7     7
+   0       PE0     8 - this one is a little odd. *
+</pre>
+
+* Note: Arduino Pin 0 is PE0 (PCINT8), which is RX0. Also, it is the only other
+pin on another port on PCI1. This would make it very costly to integrate with
+the library's code and thus is not supported by this library.  It is the same
+pin the Arduino uses to upload sketches, and it is connected to the FT232RL
+USB-to-Serial chip (ATmega16U2 on the R3).
+
 ### Mighty 1284, Bobuino, EnviroDIY Mayfly, Sodaq Mbili Support
 The ATmega 1284p shares pinout with the 644; the only difference is in memory
 size. We use the "Mighty 1284" platform as our model, because the needed files are

--- a/utility/ei_External2560.h
+++ b/utility/ei_External2560.h
@@ -2,7 +2,11 @@
 #ifdef EI_SECTION_ENABLEEXTERNAL
 switch (arduinoPin) {
 #ifndef EI_NOTINT0
+#if defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  case 18 : // INT0 (xxx1 - MegaCore pinout)
+#else
   case 21 : // INT0
+#endif
 #ifndef NEEDFORSPEED
     functionPointerArrayEXTERNAL[0] = userFunction;
 #endif
@@ -14,7 +18,11 @@ switch (arduinoPin) {
     break;
 #endif
 #ifndef EI_NOTINT1
+#if defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  case 19 : // INT1
+#else
   case 20 : // INT1
+#endif
 #ifndef NEEDFORSPEED
     functionPointerArrayEXTERNAL[1] = userFunction;
 #endif
@@ -26,7 +34,11 @@ switch (arduinoPin) {
     break; 
 #endif
 #ifndef EI_NOTINT2
+#if defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  case 20 : // INT2
+#else
   case 19 : // INT2
+#endif
 #ifndef NEEDFORSPEED
     functionPointerArrayEXTERNAL[2] = userFunction;
 #endif
@@ -38,7 +50,11 @@ switch (arduinoPin) {
     break;
 #endif
 #ifndef EI_NOTINT3
+#if defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  case 21 : // INT3
+#else
   case 18 : // INT3
+#endif
 #ifndef NEEDFORSPEED
     functionPointerArrayEXTERNAL[3] = userFunction;
 #endif
@@ -50,7 +66,11 @@ switch (arduinoPin) {
     break;
 #endif
 #ifndef EI_NOTINT4
+#if defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  case  4 : // INT4
+#else
   case  2 : // INT4
+#endif
 #ifndef NEEDFORSPEED
     functionPointerArrayEXTERNAL[4] = userFunction;
 #endif
@@ -62,7 +82,11 @@ switch (arduinoPin) {
     break;
 #endif
 #ifndef EI_NOTINT5
+#if defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  case  5 : // INT5
+#else
   case  3 : // INT5
+#endif
 #ifndef NEEDFORSPEED
     functionPointerArrayEXTERNAL[5] = userFunction;
 #endif
@@ -74,7 +98,11 @@ switch (arduinoPin) {
     break;
 #endif
 #ifndef EI_NOTINT6
+#if defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  case  6 : // INT6
+#else
   case 75 : // INT6- Fake Arduino Pin
+#endif
 #ifndef NEEDFORSPEED
     functionPointerArrayEXTERNAL[6] = userFunction;
 #endif
@@ -86,7 +114,11 @@ switch (arduinoPin) {
     break;
 #endif
 #ifndef EI_NOTINT7
+#if defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  case  7 : // INT7
+#else
   case 76 : // INT7- Fake Arduino Pin
+#endif
 #ifndef NEEDFORSPEED
     functionPointerArrayEXTERNAL[7] = userFunction;
 #endif
@@ -103,56 +135,88 @@ switch (arduinoPin) {
 #ifdef EI_SECTION_DISABLEEXTERNAL
 switch (arduinoPin) {
 #ifndef EI_NOTINT0
+#if defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  case 18 : // INT0
+#else
   case 21 : // INT0
+#endif
     EIMSK &= ~_BV(0);
     EICRA &= (~_BV(0) & ~_BV(1));
     EIFR |= _BV(0);
     break;
 #endif
 #ifndef EI_NOTINT1
+#if defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  case 19 : // INT1
+#else
   case 20 : // INT1
+#endif
     EIMSK &= ~_BV(1);
     EICRA &= (~_BV(2) & ~_BV(3));
     EIFR |= _BV(1);
     break;
 #endif
 #ifndef EI_NOTINT2
+#if defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  case 20 : // INT2
+#else
   case 19 : // INT2
+#endif
     EIMSK &= ~_BV(2);
     EICRA &= (~_BV(4) & ~_BV(5));
     EIFR |= _BV(2);
     break;
 #endif
 #ifndef EI_NOTINT3
+#if defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  case 21 : // INT3
+#else
   case 18 : // INT3
+#endif
     EIMSK &= ~_BV(3);
     EICRA &= (~_BV(6) & ~_BV(7));
     EIFR |= _BV(3);
     break; 
 #endif
 #ifndef EI_NOTINT4
+#if defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  case  4 : // INT4
+#else
   case  2 : // INT4
+#endif
     EIMSK &= ~_BV(4);
     EICRB &= (~_BV(0) & ~_BV(1));
     EIFR |= _BV(4);
     break;
 #endif
 #ifndef EI_NOTINT5
+#if defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  case  5 : // INT5
+#else
   case  3 : // INT5
+#endif
     EIMSK &= ~_BV(5);
     EICRB &= (~_BV(2) & ~_BV(3));
     EIFR |= _BV(5);
     break;
 #endif
 #ifndef EI_NOTINT6
+#if defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  case  6 : // INT6
+#else
   case 75 : // INT6- Fake Arduino Pin
+#endif
     EIMSK &= ~_BV(6);
     EICRB &= (~_BV(4) & ~_BV(5));
     EIFR |= _BV(6);
     break;
 #endif
 #ifndef EI_NOTINT7
+#if defined __AVR_ATmega1281__ || defined __AVR_ATmega2561__
+  case  7 : // INT7
+#else
   case 76 : // INT7- Fake Arduino Pin
+#endif
     EIMSK &= ~_BV(7);
     EICRB &= (~_BV(6) & ~_BV(7));
     EIFR |= _BV(7);


### PR DESCRIPTION
I've modified your library to support the ATmega2561 and 1281 chips, with pinouts defined from the MCUdude/MegaCore project. I've tested the changes on a custom board using the ATmega1281 chip and from my testing they are working.
Thought I would offer these changes up to see if you were interested in including them.